### PR TITLE
Adding js lock files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+yarn.lock
+package-lock.json


### PR DESCRIPTION
Performing an `npm install` or a `yarn install` will cause the git tree to be dirty due to the existence of a lock file. Setting to ignore. Or, should these be checked in?