### PR TITLE
Moving typescript locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "outdir/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tsc",
+    "build": "node_modules/.bin/tsc",
     "start": "node_modules/.bin/electron dist/index.js",
-    "glow": "tsc && node_modules/.bin/electron dist/index.js"
+    "glow": "node_modules/.bin/tsc && node_modules/.bin/electron dist/index.js"
   },
   "keywords": [
     "macos",
@@ -17,7 +17,8 @@
   "author": "technosophos",
   "license": "MIT",
   "devDependencies": {
-    "electron": "1.6.11"
+    "electron": "1.6.11",
+    "typescript": "^2.5.2"
   },
   "dependencies": {
     "applescript": "^1.0.0",


### PR DESCRIPTION
The current setup assumes typescript is installed globally. This
change moves it to a local dev dependency.